### PR TITLE
Fix image name in scan workflow

### DIFF
--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -22,7 +22,7 @@ permissions:
 env:
   SUPPORTED_RELEASES_NUMBER: '1'
   # comma separated list of images, without tag
-  IMAGES: "xpkg.upbound.io/upbound/provider-family-gcp"
+  IMAGES: "xpkg.upbound.io/upbound/provider-family-gcp-beta"
 
 jobs:
   setup-vars:


### PR DESCRIPTION
### Description of your changes

Fixes image name in scan workflow

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR if necessary.~

### How has this code been tested

Tested `turkenf/provider-upjet-gcp-beta`, Only the Upload Trivy Scan Results To GitHub Security Tab step could not be tested, as it is available for the organization.

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
