### PR TITLE
Update go version to 1.23.6 [SECURITY]

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/upbound/provider-gcp-beta
 
-go 1.23.5
+go 1.23.6
 
 require (
 	dario.cat/mergo v1.0.0


### PR DESCRIPTION
### Description of your changes

This PR updates `go.mod` dependencies to fix the following:

| Name | Change | Type | Vulnerability | Severity |
|---|---|---|---|---|
| stdlib | `go1.23.5` -> `go1.23.6` | go-module | CVE-2025-22866 | Unknown |

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

https://github.com/upbound/provider-upjet-gcp-beta/actions/runs/13240914251

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
