### PR TITLE
add basic plumbing for provider startup checks.

### DIFF
--- a/cmd/provider/cloudplatform/zz_main.go
+++ b/cmd/provider/cloudplatform/zz_main.go
@@ -39,6 +39,7 @@ import (
 	"github.com/upbound/provider-gcp-beta/apis/v1alpha1"
 	"github.com/upbound/provider-gcp-beta/config"
 	resolverapis "github.com/upbound/provider-gcp-beta/internal/apis"
+	"github.com/upbound/provider-gcp-beta/internal/bootcheck"
 	"github.com/upbound/provider-gcp-beta/internal/clients"
 	"github.com/upbound/provider-gcp-beta/internal/controller"
 	"github.com/upbound/provider-gcp-beta/internal/features"
@@ -56,6 +57,13 @@ func deprecationAction(flagName string) kingpin.Action {
 		_, err := fmt.Fprintf(os.Stderr, "warning: Command-line flag %q is deprecated and no longer used. It will be removed in a future release. Please remove it from all of your configurations (ControllerConfigs, etc.).\n", flagName)
 		kingpin.FatalIfError(err, "Failed to print the deprecation notice.")
 		return nil
+	}
+}
+
+func init() {
+	err := bootcheck.CheckEnv()
+	if err != nil {
+		log.Fatalf("bootcheck failed. provider will not be started: %v", err)
 	}
 }
 

--- a/cmd/provider/compute/zz_main.go
+++ b/cmd/provider/compute/zz_main.go
@@ -39,6 +39,7 @@ import (
 	"github.com/upbound/provider-gcp-beta/apis/v1alpha1"
 	"github.com/upbound/provider-gcp-beta/config"
 	resolverapis "github.com/upbound/provider-gcp-beta/internal/apis"
+	"github.com/upbound/provider-gcp-beta/internal/bootcheck"
 	"github.com/upbound/provider-gcp-beta/internal/clients"
 	"github.com/upbound/provider-gcp-beta/internal/controller"
 	"github.com/upbound/provider-gcp-beta/internal/features"
@@ -56,6 +57,13 @@ func deprecationAction(flagName string) kingpin.Action {
 		_, err := fmt.Fprintf(os.Stderr, "warning: Command-line flag %q is deprecated and no longer used. It will be removed in a future release. Please remove it from all of your configurations (ControllerConfigs, etc.).\n", flagName)
 		kingpin.FatalIfError(err, "Failed to print the deprecation notice.")
 		return nil
+	}
+}
+
+func init() {
+	err := bootcheck.CheckEnv()
+	if err != nil {
+		log.Fatalf("bootcheck failed. provider will not be started: %v", err)
 	}
 }
 

--- a/cmd/provider/config/zz_main.go
+++ b/cmd/provider/config/zz_main.go
@@ -39,6 +39,7 @@ import (
 	"github.com/upbound/provider-gcp-beta/apis/v1alpha1"
 	"github.com/upbound/provider-gcp-beta/config"
 	resolverapis "github.com/upbound/provider-gcp-beta/internal/apis"
+	"github.com/upbound/provider-gcp-beta/internal/bootcheck"
 	"github.com/upbound/provider-gcp-beta/internal/clients"
 	"github.com/upbound/provider-gcp-beta/internal/controller"
 	"github.com/upbound/provider-gcp-beta/internal/features"
@@ -56,6 +57,13 @@ func deprecationAction(flagName string) kingpin.Action {
 		_, err := fmt.Fprintf(os.Stderr, "warning: Command-line flag %q is deprecated and no longer used. It will be removed in a future release. Please remove it from all of your configurations (ControllerConfigs, etc.).\n", flagName)
 		kingpin.FatalIfError(err, "Failed to print the deprecation notice.")
 		return nil
+	}
+}
+
+func init() {
+	err := bootcheck.CheckEnv()
+	if err != nil {
+		log.Fatalf("bootcheck failed. provider will not be started: %v", err)
 	}
 }
 

--- a/cmd/provider/container/zz_main.go
+++ b/cmd/provider/container/zz_main.go
@@ -39,6 +39,7 @@ import (
 	"github.com/upbound/provider-gcp-beta/apis/v1alpha1"
 	"github.com/upbound/provider-gcp-beta/config"
 	resolverapis "github.com/upbound/provider-gcp-beta/internal/apis"
+	"github.com/upbound/provider-gcp-beta/internal/bootcheck"
 	"github.com/upbound/provider-gcp-beta/internal/clients"
 	"github.com/upbound/provider-gcp-beta/internal/controller"
 	"github.com/upbound/provider-gcp-beta/internal/features"
@@ -56,6 +57,13 @@ func deprecationAction(flagName string) kingpin.Action {
 		_, err := fmt.Fprintf(os.Stderr, "warning: Command-line flag %q is deprecated and no longer used. It will be removed in a future release. Please remove it from all of your configurations (ControllerConfigs, etc.).\n", flagName)
 		kingpin.FatalIfError(err, "Failed to print the deprecation notice.")
 		return nil
+	}
+}
+
+func init() {
+	err := bootcheck.CheckEnv()
+	if err != nil {
+		log.Fatalf("bootcheck failed. provider will not be started: %v", err)
 	}
 }
 

--- a/cmd/provider/monolith/zz_main.go
+++ b/cmd/provider/monolith/zz_main.go
@@ -39,6 +39,7 @@ import (
 	"github.com/upbound/provider-gcp-beta/apis/v1alpha1"
 	"github.com/upbound/provider-gcp-beta/config"
 	resolverapis "github.com/upbound/provider-gcp-beta/internal/apis"
+	"github.com/upbound/provider-gcp-beta/internal/bootcheck"
 	"github.com/upbound/provider-gcp-beta/internal/clients"
 	"github.com/upbound/provider-gcp-beta/internal/controller"
 	"github.com/upbound/provider-gcp-beta/internal/features"
@@ -56,6 +57,13 @@ func deprecationAction(flagName string) kingpin.Action {
 		_, err := fmt.Fprintf(os.Stderr, "warning: Command-line flag %q is deprecated and no longer used. It will be removed in a future release. Please remove it from all of your configurations (ControllerConfigs, etc.).\n", flagName)
 		kingpin.FatalIfError(err, "Failed to print the deprecation notice.")
 		return nil
+	}
+}
+
+func init() {
+	err := bootcheck.CheckEnv()
+	if err != nil {
+		log.Fatalf("bootcheck failed. provider will not be started: %v", err)
 	}
 }
 

--- a/cmd/provider/networksecurity/zz_main.go
+++ b/cmd/provider/networksecurity/zz_main.go
@@ -39,6 +39,7 @@ import (
 	"github.com/upbound/provider-gcp-beta/apis/v1alpha1"
 	"github.com/upbound/provider-gcp-beta/config"
 	resolverapis "github.com/upbound/provider-gcp-beta/internal/apis"
+	"github.com/upbound/provider-gcp-beta/internal/bootcheck"
 	"github.com/upbound/provider-gcp-beta/internal/clients"
 	"github.com/upbound/provider-gcp-beta/internal/controller"
 	"github.com/upbound/provider-gcp-beta/internal/features"
@@ -56,6 +57,13 @@ func deprecationAction(flagName string) kingpin.Action {
 		_, err := fmt.Fprintf(os.Stderr, "warning: Command-line flag %q is deprecated and no longer used. It will be removed in a future release. Please remove it from all of your configurations (ControllerConfigs, etc.).\n", flagName)
 		kingpin.FatalIfError(err, "Failed to print the deprecation notice.")
 		return nil
+	}
+}
+
+func init() {
+	err := bootcheck.CheckEnv()
+	if err != nil {
+		log.Fatalf("bootcheck failed. provider will not be started: %v", err)
 	}
 }
 

--- a/hack/main.go.tmpl
+++ b/hack/main.go.tmpl
@@ -39,6 +39,7 @@ import (
 	"github.com/upbound/provider-gcp-beta/apis/v1alpha1"
 	"github.com/upbound/provider-gcp-beta/config"
 	resolverapis "github.com/upbound/provider-gcp-beta/internal/apis"
+	"github.com/upbound/provider-gcp-beta/internal/bootcheck"
 	"github.com/upbound/provider-gcp-beta/internal/clients"
 	"github.com/upbound/provider-gcp-beta/internal/controller"
 	"github.com/upbound/provider-gcp-beta/internal/features"
@@ -56,6 +57,13 @@ func deprecationAction(flagName string) kingpin.Action {
 		_, err := fmt.Fprintf(os.Stderr, "warning: Command-line flag %q is deprecated and no longer used. It will be removed in a future release. Please remove it from all of your configurations (ControllerConfigs, etc.).\n", flagName)
 		kingpin.FatalIfError(err, "Failed to print the deprecation notice.")
 		return nil
+	}
+}
+
+func init() {
+	err := bootcheck.CheckEnv()
+	if err != nil {
+		log.Fatalf("bootcheck failed. provider will not be started: %v", err)
 	}
 }
 

--- a/internal/bootcheck/default.go
+++ b/internal/bootcheck/default.go
@@ -1,0 +1,14 @@
+//go:build !custombootcheck
+// +build !custombootcheck
+
+// SPDX-FileCopyrightText: 2025 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package bootcheck
+
+func CheckEnv() error {
+	// No-op by default. Use build tags for build-time isolation of custom preflight checks.
+	// Ensure to update the build tags on L1-L2 so that they are mutually exclusive across implementations.
+	return nil
+}


### PR DESCRIPTION
<!--
Please read through https://git.io/fj2m9 if this is your first time opening a
pull request to this repo. Find us in https://crossplane.slack.com
if you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your
reviewers' attention to anything that needs special consideration.

We love pull requests that resolve an open issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":
-->

Similar to https://github.com/crossplane-contrib/provider-upjet-aws/pull/1818, this PR proposes a simple approach to enable custom startup checks on the provider by updating the main.go.tmpl. As a concrete example, users may run their workloads in highly regulated environments where the provider should not start if the environment is not properly configured.

This implements the default path, which is a no-op. It uses a combination of an `init()` hook and [go build tags](https://pkg.go.dev/go/build#hdr-Build_Constraints) to:

- minimize code branching (build-time isolation)
- ensure critical checks run before anything else (fail fast)
- not require access to additional flags, env, or setup

A (simplified) example of an alternative implementation is building images with a compliance check (e.g. running in a FIPS-enabled host). What that would look like is:

- add `internal/bootcheck/fips.go`
   - add the build tags and adjust the default as needed.
    ```
         //go:build fips
         // +build fips
    ```
- build the images as before with `GO_TAGS=fips` to produce images targeting that specific compliance check.

I have:

- [ ] Read and followed Crossplane's [contribution process].
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->
local build and install.
[contribution process]: https://git.io/fj2m9
