### PR TITLE
Bump storage&controller version for CRDs that served multi-version, and start deprecation process for the old versions

### DIFF
--- a/apis/cluster/container/v1beta1/zz_cluster_types.go
+++ b/apis/cluster/container/v1beta1/zz_cluster_types.go
@@ -6652,9 +6652,10 @@ type ClusterStatus struct {
 
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
-// +kubebuilder:storageversion
+// +kubebuilder:deprecatedversion:warning="This API version is deprecated. Deprecated since v1.1.0."
 
 // Cluster is the Schema for the Clusters API. Creates a Google Kubernetes Engine (GKE) cluster.
+// Deprecated: This API version (v1beta1) has been deprecated in release v1.1.0.
 // +kubebuilder:printcolumn:name="SYNCED",type="string",JSONPath=".status.conditions[?(@.type=='Synced')].status"
 // +kubebuilder:printcolumn:name="READY",type="string",JSONPath=".status.conditions[?(@.type=='Ready')].status"
 // +kubebuilder:printcolumn:name="EXTERNAL-NAME",type="string",JSONPath=".metadata.annotations.crossplane\\.io/external-name"

--- a/apis/cluster/container/v1beta1/zz_nodepool_types.go
+++ b/apis/cluster/container/v1beta1/zz_nodepool_types.go
@@ -1896,9 +1896,10 @@ type NodePoolStatus struct {
 
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
-// +kubebuilder:storageversion
+// +kubebuilder:deprecatedversion:warning="This API version is deprecated. Deprecated since v1.1.0."
 
 // NodePool is the Schema for the NodePools API. Manages a GKE NodePool resource.
+// Deprecated: This API version (v1beta1) has been deprecated in release v1.1.0.
 // +kubebuilder:printcolumn:name="SYNCED",type="string",JSONPath=".status.conditions[?(@.type=='Synced')].status"
 // +kubebuilder:printcolumn:name="READY",type="string",JSONPath=".status.conditions[?(@.type=='Ready')].status"
 // +kubebuilder:printcolumn:name="EXTERNAL-NAME",type="string",JSONPath=".metadata.annotations.crossplane\\.io/external-name"

--- a/apis/cluster/container/v1beta2/zz_cluster_types.go
+++ b/apis/cluster/container/v1beta2/zz_cluster_types.go
@@ -6685,6 +6685,7 @@ type ClusterStatus struct {
 
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
+// +kubebuilder:storageversion
 
 // Cluster is the Schema for the Clusters API. Creates a Google Kubernetes Engine (GKE) cluster.
 // +kubebuilder:printcolumn:name="SYNCED",type="string",JSONPath=".status.conditions[?(@.type=='Synced')].status"

--- a/apis/cluster/container/v1beta2/zz_nodepool_types.go
+++ b/apis/cluster/container/v1beta2/zz_nodepool_types.go
@@ -1896,6 +1896,7 @@ type NodePoolStatus struct {
 
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
+// +kubebuilder:storageversion
 
 // NodePool is the Schema for the NodePools API. Manages a GKE NodePool resource.
 // +kubebuilder:printcolumn:name="SYNCED",type="string",JSONPath=".status.conditions[?(@.type=='Synced')].status"

--- a/config/cluster/container/config.go
+++ b/config/cluster/container/config.go
@@ -116,7 +116,7 @@ func Configure(p *config.Provider) { //nolint:gocyclo
 				"kubeconfig": kcb,
 			}, nil
 		}
-		config.MarkAsRequired(r.TerraformResource, "location")
+		r.MarkAsRequired("location")
 		r.TerraformCustomDiff = func(diff *terraform.InstanceDiff, _ *terraform.InstanceState, _ *terraform.ResourceConfig) (*terraform.InstanceDiff, error) {
 			if diff != nil {
 				delete(diff.Attributes, "tpu_config.#")

--- a/config/cluster/networksecurity/config.go
+++ b/config/cluster/networksecurity/config.go
@@ -10,7 +10,7 @@ import "github.com/crossplane/upjet/v2/pkg/config"
 // ResourceConfigurators.
 func Configure(p *config.Provider) {
 	p.AddResourceConfigurator("google_network_security_server_tls_policy", func(r *config.Resource) {
-		config.MarkAsRequired(r.TerraformResource, "location")
+		r.MarkAsRequired("location")
 		r.ShortGroup = "networksecurity"
 		r.Kind = "ServerTLSPolicy"
 	})

--- a/config/namespaced/container/config.go
+++ b/config/namespaced/container/config.go
@@ -116,7 +116,7 @@ func Configure(p *config.Provider) { //nolint:gocyclo
 				"kubeconfig": kcb,
 			}, nil
 		}
-		config.MarkAsRequired(r.TerraformResource, "location")
+		r.MarkAsRequired("location")
 		r.TerraformCustomDiff = func(diff *terraform.InstanceDiff, _ *terraform.InstanceState, _ *terraform.ResourceConfig) (*terraform.InstanceDiff, error) {
 			if diff != nil {
 				delete(diff.Attributes, "tpu_config.#")

--- a/config/namespaced/networksecurity/config.go
+++ b/config/namespaced/networksecurity/config.go
@@ -10,7 +10,7 @@ import "github.com/crossplane/upjet/v2/pkg/config"
 // ResourceConfigurators.
 func Configure(p *config.Provider) {
 	p.AddResourceConfigurator("google_network_security_server_tls_policy", func(r *config.Resource) {
-		config.MarkAsRequired(r.TerraformResource, "location")
+		r.MarkAsRequired("location")
 		r.ShortGroup = "networksecurity"
 		r.Kind = "ServerTLSPolicy"
 	})

--- a/config/provider_cluster.go
+++ b/config/provider_cluster.go
@@ -10,7 +10,6 @@ import (
 	_ "embed"
 	"strings"
 
-	"github.com/crossplane/upjet/v2/pkg/config"
 	ujconfig "github.com/crossplane/upjet/v2/pkg/config"
 	"github.com/crossplane/upjet/v2/pkg/config/conversion"
 	"github.com/crossplane/upjet/v2/pkg/registry/reference"
@@ -116,24 +115,22 @@ func bumpVersionsWithEmbeddedLists(pc *ujconfig.Provider) {
 		if _, ok := oldSLAPIs[n]; ok {
 			r.Version = "v1beta2"
 			r.PreviousVersions = []string{"v1beta1"}
-			// we would like to set the storage version to v1beta1 to facilitate
-			// downgrades.
-			r.SetCRDStorageVersion("v1beta1")
-			// because the controller reconciles on the API version with the singleton list API,
-			// no need for a Terraform conversion.
-			r.ControllerReconcileVersion = "v1beta1"
+			r.SetCRDStorageVersion(r.Version)
+			r.ControllerReconcileVersion = r.Version //nolint:staticcheck
 			r.Conversions = []conversion.Conversion{
 				conversion.NewIdentityConversionExpandPaths(conversion.AllVersions, conversion.AllVersions, conversion.DefaultPathPrefixes(), r.CRDListConversionPaths()...),
 				conversion.NewSingletonListConversion("v1beta1", "v1beta2", conversion.DefaultPathPrefixes(), r.CRDListConversionPaths(), conversion.ToEmbeddedObject),
 				conversion.NewSingletonListConversion("v1beta2", "v1beta1", conversion.DefaultPathPrefixes(), r.CRDListConversionPaths(), conversion.ToSingletonList)}
-		} else {
-			// the controller will be reconciling on the CRD API version
-			// with the converted API (with embedded objects in place of
-			// singleton lists), so we need the appropriate Terraform
-			// converter in this case.
-			r.TerraformConversions = []config.TerraformConversion{
-				config.NewTFSingletonConversion(),
+			if err := r.SetDeprecatedVersion("v1beta1",
+				ujconfig.VersionDeprecation{
+					Warning:            "This API version is deprecated.",
+					DeprecationRelease: "v1.1.0",
+				}); err != nil {
+				panic(err)
 			}
+		}
+		r.TerraformConversions = []ujconfig.TerraformConversion{
+			ujconfig.NewTFSingletonConversion(),
 		}
 		pc.Resources[n] = r
 	}

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/alecthomas/kingpin/v2 v2.4.0
 	github.com/crossplane/crossplane-runtime/v2 v2.0.0-rc.1
 	github.com/crossplane/crossplane-tools v0.0.0-20250731192036-00d407d8b7ec
-	github.com/crossplane/upjet/v2 v2.0.1-0.20251009193737-0b7f640373c8
+	github.com/crossplane/upjet/v2 v2.2.1-0.20260202111611-56fd3e8c5b3b
 	github.com/hashicorp/terraform-json v0.25.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.37.0
 	github.com/hashicorp/terraform-provider-google-beta v1.20.1-0.20250610151054-ddaee814b79f
@@ -119,7 +119,7 @@ require (
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
-	github.com/muvaf/typewriter v0.0.0-20210910160850-80e49fe1eb32 // indirect
+	github.com/muvaf/typewriter v0.0.0-20240614220100-70f9d4a54ea0 // indirect
 	github.com/oklog/run v1.0.0 // indirect
 	github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10 // indirect
 	github.com/prometheus/client_golang v1.22.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -70,8 +70,8 @@ github.com/crossplane/crossplane-runtime/v2 v2.0.0-rc.1 h1:ux9lBmdZbYyQPsnJIDLFl
 github.com/crossplane/crossplane-runtime/v2 v2.0.0-rc.1/go.mod h1:pkd5UzmE8esaZAApevMutR832GjJ1Qgc5Ngr78ByxrI=
 github.com/crossplane/crossplane-tools v0.0.0-20250731192036-00d407d8b7ec h1:+51Et4UW8XrvGne8RAqn9qEIfhoqPXYqIp/kQvpMaAo=
 github.com/crossplane/crossplane-tools v0.0.0-20250731192036-00d407d8b7ec/go.mod h1:8etxwmP4cZwJDwen4+PQlnc1tggltAhEfyyigmdHulQ=
-github.com/crossplane/upjet/v2 v2.0.1-0.20251009193737-0b7f640373c8 h1:zdxlqcXtEhqb7YKsipQk4lIfLhp42UuJSAyFTw+LhAs=
-github.com/crossplane/upjet/v2 v2.0.1-0.20251009193737-0b7f640373c8/go.mod h1:nXboF68y9ZQRu39kZirQQiPL/BA4Afic17rEdHE+VQo=
+github.com/crossplane/upjet/v2 v2.2.1-0.20260202111611-56fd3e8c5b3b h1:PEfIa5HXhRdgcVhGD9bvUe6NFuXRT18ymEEvi+zjtFE=
+github.com/crossplane/upjet/v2 v2.2.1-0.20260202111611-56fd3e8c5b3b/go.mod h1:jDCqvAFLrVEzqE+pywmQ5u18HbJK5j5Jj4cTQpqOLqY=
 github.com/dave/jennifer v1.7.1 h1:B4jJJDHelWcDhlRQxWeo0Npa/pYKBLrirAQoTN45txo=
 github.com/dave/jennifer v1.7.1/go.mod h1:nXbxhEmQfOZhWml3D1cDK5M1FLnMSozpbFN/m3RmGZc=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -304,8 +304,8 @@ github.com/modern-go/reflect2 v1.0.2 h1:xBagoLtFs94CBntxluKeaWgTMpvLxC4ur3nMaC9G
 github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
-github.com/muvaf/typewriter v0.0.0-20210910160850-80e49fe1eb32 h1:yBQlHXLeUJL3TWVmzup5uT3wG5FLxhiTAiTsmNVocys=
-github.com/muvaf/typewriter v0.0.0-20210910160850-80e49fe1eb32/go.mod h1:SAAdeMEiFXR8LcHffvIdiLI1w243DCH2DuHq7UrA5YQ=
+github.com/muvaf/typewriter v0.0.0-20240614220100-70f9d4a54ea0 h1:05HUfXEb9O/nGF32uKsjjYeGJBZ6PeVHMeqetyXUgR8=
+github.com/muvaf/typewriter v0.0.0-20240614220100-70f9d4a54ea0/go.mod h1:SAAdeMEiFXR8LcHffvIdiLI1w243DCH2DuHq7UrA5YQ=
 github.com/nxadm/tail v1.4.8 h1:nPr65rt6Y5JFSKQO7qToXr7pePgD6Gwiw05lkbyAQTE=
 github.com/nxadm/tail v1.4.8/go.mod h1:+ncqLTQzXmGhMZNUePPaPqPvBxHAIsmXswZKocGu+AU=
 github.com/oklog/run v1.0.0 h1:Ru7dDtJNOyC66gQ5dQmaCa0qIsAUFY3sFpK1Xk8igrw=

--- a/internal/controller/cluster/container/cluster/zz_controller.go
+++ b/internal/controller/cluster/container/cluster/zz_controller.go
@@ -21,7 +21,7 @@ import (
 	"github.com/pkg/errors"
 	ctrl "sigs.k8s.io/controller-runtime"
 
-	v1beta1 "github.com/upbound/provider-gcp-beta/apis/cluster/container/v1beta1"
+	v1beta2 "github.com/upbound/provider-gcp-beta/apis/cluster/container/v1beta2"
 	features "github.com/upbound/provider-gcp-beta/internal/features"
 )
 
@@ -29,26 +29,26 @@ import (
 func SetupGated(mgr ctrl.Manager, o tjcontroller.Options) error {
 	o.Options.Gate.Register(func() {
 		if err := Setup(mgr, o); err != nil {
-			mgr.GetLogger().Error(err, "unable to setup reconciler", "gvk", v1beta1.Cluster_GroupVersionKind.String())
+			mgr.GetLogger().Error(err, "unable to setup reconciler", "gvk", v1beta2.Cluster_GroupVersionKind.String())
 		}
-	}, v1beta1.Cluster_GroupVersionKind)
+	}, v1beta2.Cluster_GroupVersionKind)
 	return nil
 }
 
 // Setup adds a controller that reconciles Cluster managed resources.
 func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
-	name := managed.ControllerName(v1beta1.Cluster_GroupVersionKind.String())
+	name := managed.ControllerName(v1beta2.Cluster_GroupVersionKind.String())
 	var initializers managed.InitializerChain
 	initializers = append(initializers, managed.NewNameAsExternalName(mgr.GetClient()))
-	eventHandler := handler.NewEventHandler(handler.WithLogger(o.Logger.WithValues("gvk", v1beta1.Cluster_GroupVersionKind)))
-	ac := tjcontroller.NewAPICallbacks(mgr, xpresource.ManagedKind(v1beta1.Cluster_GroupVersionKind), tjcontroller.WithEventHandler(eventHandler), tjcontroller.WithStatusUpdates(false))
+	eventHandler := handler.NewEventHandler(handler.WithLogger(o.Logger.WithValues("gvk", v1beta2.Cluster_GroupVersionKind)))
+	ac := tjcontroller.NewAPICallbacks(mgr, xpresource.ManagedKind(v1beta2.Cluster_GroupVersionKind), tjcontroller.WithEventHandler(eventHandler), tjcontroller.WithStatusUpdates(false))
 	opts := []managed.ReconcilerOption{
 		managed.WithExternalConnecter(
 			tjcontroller.NewTerraformPluginSDKAsyncConnector(mgr.GetClient(), o.OperationTrackerStore, o.SetupFn, o.Provider.Resources["google_container_cluster"],
 				tjcontroller.WithTerraformPluginSDKAsyncLogger(o.Logger),
 				tjcontroller.WithTerraformPluginSDKAsyncConnectorEventHandler(eventHandler),
 				tjcontroller.WithTerraformPluginSDKAsyncCallbackProvider(ac),
-				tjcontroller.WithTerraformPluginSDKAsyncMetricRecorder(metrics.NewMetricRecorder(v1beta1.Cluster_GroupVersionKind, mgr, o.PollInterval)),
+				tjcontroller.WithTerraformPluginSDKAsyncMetricRecorder(metrics.NewMetricRecorder(v1beta2.Cluster_GroupVersionKind, mgr, o.PollInterval)),
 				tjcontroller.WithTerraformPluginSDKAsyncManagementPolicies(o.Features.Enabled(features.EnableBetaManagementPolicies)))),
 		managed.WithLogger(o.Logger.WithValues("controller", name)),
 		managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name))),
@@ -67,22 +67,22 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		opts = append(opts, managed.WithMetricRecorder(o.MetricOptions.MRMetrics))
 	}
 
-	// register webhooks for the kind v1beta1.Cluster
+	// register webhooks for the kind v1beta2.Cluster
 	// if they're enabled.
 	if o.StartWebhooks {
 		if err := ctrl.NewWebhookManagedBy(mgr).
-			For(&v1beta1.Cluster{}).
+			For(&v1beta2.Cluster{}).
 			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1beta1.Cluster")
+			return errors.Wrap(err, "cannot register webhook for the kind v1beta2.Cluster")
 		}
 	}
 
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {
 		stateMetricsRecorder := statemetrics.NewMRStateRecorder(
-			mgr.GetClient(), o.Logger, o.MetricOptions.MRStateMetrics, &v1beta1.ClusterList{}, o.MetricOptions.PollStateMetricInterval,
+			mgr.GetClient(), o.Logger, o.MetricOptions.MRStateMetrics, &v1beta2.ClusterList{}, o.MetricOptions.PollStateMetricInterval,
 		)
 		if err := mgr.Add(stateMetricsRecorder); err != nil {
-			return errors.Wrap(err, "cannot register MR state metrics recorder for kind v1beta1.ClusterList")
+			return errors.Wrap(err, "cannot register MR state metrics recorder for kind v1beta2.ClusterList")
 		}
 	}
 
@@ -90,12 +90,12 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		opts = append(opts, managed.WithChangeLogger(o.ChangeLogOptions.ChangeLogger))
 	}
 
-	r := managed.NewReconciler(mgr, xpresource.ManagedKind(v1beta1.Cluster_GroupVersionKind), opts...)
+	r := managed.NewReconciler(mgr, xpresource.ManagedKind(v1beta2.Cluster_GroupVersionKind), opts...)
 
 	return ctrl.NewControllerManagedBy(mgr).
 		Named(name).
 		WithOptions(o.ForControllerRuntime()).
 		WithEventFilter(xpresource.DesiredStateChanged()).
-		Watches(&v1beta1.Cluster{}, eventHandler).
+		Watches(&v1beta2.Cluster{}, eventHandler).
 		Complete(ratelimiter.NewReconciler(name, r, o.GlobalRateLimiter))
 }

--- a/internal/controller/cluster/container/nodepool/zz_controller.go
+++ b/internal/controller/cluster/container/nodepool/zz_controller.go
@@ -21,7 +21,7 @@ import (
 	"github.com/pkg/errors"
 	ctrl "sigs.k8s.io/controller-runtime"
 
-	v1beta1 "github.com/upbound/provider-gcp-beta/apis/cluster/container/v1beta1"
+	v1beta2 "github.com/upbound/provider-gcp-beta/apis/cluster/container/v1beta2"
 	features "github.com/upbound/provider-gcp-beta/internal/features"
 )
 
@@ -29,26 +29,26 @@ import (
 func SetupGated(mgr ctrl.Manager, o tjcontroller.Options) error {
 	o.Options.Gate.Register(func() {
 		if err := Setup(mgr, o); err != nil {
-			mgr.GetLogger().Error(err, "unable to setup reconciler", "gvk", v1beta1.NodePool_GroupVersionKind.String())
+			mgr.GetLogger().Error(err, "unable to setup reconciler", "gvk", v1beta2.NodePool_GroupVersionKind.String())
 		}
-	}, v1beta1.NodePool_GroupVersionKind)
+	}, v1beta2.NodePool_GroupVersionKind)
 	return nil
 }
 
 // Setup adds a controller that reconciles NodePool managed resources.
 func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
-	name := managed.ControllerName(v1beta1.NodePool_GroupVersionKind.String())
+	name := managed.ControllerName(v1beta2.NodePool_GroupVersionKind.String())
 	var initializers managed.InitializerChain
 	initializers = append(initializers, managed.NewNameAsExternalName(mgr.GetClient()))
-	eventHandler := handler.NewEventHandler(handler.WithLogger(o.Logger.WithValues("gvk", v1beta1.NodePool_GroupVersionKind)))
-	ac := tjcontroller.NewAPICallbacks(mgr, xpresource.ManagedKind(v1beta1.NodePool_GroupVersionKind), tjcontroller.WithEventHandler(eventHandler), tjcontroller.WithStatusUpdates(false))
+	eventHandler := handler.NewEventHandler(handler.WithLogger(o.Logger.WithValues("gvk", v1beta2.NodePool_GroupVersionKind)))
+	ac := tjcontroller.NewAPICallbacks(mgr, xpresource.ManagedKind(v1beta2.NodePool_GroupVersionKind), tjcontroller.WithEventHandler(eventHandler), tjcontroller.WithStatusUpdates(false))
 	opts := []managed.ReconcilerOption{
 		managed.WithExternalConnecter(
 			tjcontroller.NewTerraformPluginSDKAsyncConnector(mgr.GetClient(), o.OperationTrackerStore, o.SetupFn, o.Provider.Resources["google_container_node_pool"],
 				tjcontroller.WithTerraformPluginSDKAsyncLogger(o.Logger),
 				tjcontroller.WithTerraformPluginSDKAsyncConnectorEventHandler(eventHandler),
 				tjcontroller.WithTerraformPluginSDKAsyncCallbackProvider(ac),
-				tjcontroller.WithTerraformPluginSDKAsyncMetricRecorder(metrics.NewMetricRecorder(v1beta1.NodePool_GroupVersionKind, mgr, o.PollInterval)),
+				tjcontroller.WithTerraformPluginSDKAsyncMetricRecorder(metrics.NewMetricRecorder(v1beta2.NodePool_GroupVersionKind, mgr, o.PollInterval)),
 				tjcontroller.WithTerraformPluginSDKAsyncManagementPolicies(o.Features.Enabled(features.EnableBetaManagementPolicies)))),
 		managed.WithLogger(o.Logger.WithValues("controller", name)),
 		managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name))),
@@ -67,22 +67,22 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		opts = append(opts, managed.WithMetricRecorder(o.MetricOptions.MRMetrics))
 	}
 
-	// register webhooks for the kind v1beta1.NodePool
+	// register webhooks for the kind v1beta2.NodePool
 	// if they're enabled.
 	if o.StartWebhooks {
 		if err := ctrl.NewWebhookManagedBy(mgr).
-			For(&v1beta1.NodePool{}).
+			For(&v1beta2.NodePool{}).
 			Complete(); err != nil {
-			return errors.Wrap(err, "cannot register webhook for the kind v1beta1.NodePool")
+			return errors.Wrap(err, "cannot register webhook for the kind v1beta2.NodePool")
 		}
 	}
 
 	if o.MetricOptions != nil && o.MetricOptions.MRStateMetrics != nil {
 		stateMetricsRecorder := statemetrics.NewMRStateRecorder(
-			mgr.GetClient(), o.Logger, o.MetricOptions.MRStateMetrics, &v1beta1.NodePoolList{}, o.MetricOptions.PollStateMetricInterval,
+			mgr.GetClient(), o.Logger, o.MetricOptions.MRStateMetrics, &v1beta2.NodePoolList{}, o.MetricOptions.PollStateMetricInterval,
 		)
 		if err := mgr.Add(stateMetricsRecorder); err != nil {
-			return errors.Wrap(err, "cannot register MR state metrics recorder for kind v1beta1.NodePoolList")
+			return errors.Wrap(err, "cannot register MR state metrics recorder for kind v1beta2.NodePoolList")
 		}
 	}
 
@@ -90,12 +90,12 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		opts = append(opts, managed.WithChangeLogger(o.ChangeLogOptions.ChangeLogger))
 	}
 
-	r := managed.NewReconciler(mgr, xpresource.ManagedKind(v1beta1.NodePool_GroupVersionKind), opts...)
+	r := managed.NewReconciler(mgr, xpresource.ManagedKind(v1beta2.NodePool_GroupVersionKind), opts...)
 
 	return ctrl.NewControllerManagedBy(mgr).
 		Named(name).
 		WithOptions(o.ForControllerRuntime()).
 		WithEventFilter(xpresource.DesiredStateChanged()).
-		Watches(&v1beta1.NodePool{}, eventHandler).
+		Watches(&v1beta2.NodePool{}, eventHandler).
 		Complete(ratelimiter.NewReconciler(name, r, o.GlobalRateLimiter))
 }

--- a/package/crds/container.gcp-beta.upbound.io_clusters.yaml
+++ b/package/crds/container.gcp-beta.upbound.io_clusters.yaml
@@ -31,11 +31,14 @@ spec:
     - jsonPath: .metadata.creationTimestamp
       name: AGE
       type: date
+    deprecated: true
+    deprecationWarning: This API version is deprecated. Deprecated since v1.1.0.
     name: v1beta1
     schema:
       openAPIV3Schema:
-        description: Cluster is the Schema for the Clusters API. Creates a Google
-          Kubernetes Engine (GKE) cluster.
+        description: |-
+          Cluster is the Schema for the Clusters API. Creates a Google Kubernetes Engine (GKE) cluster.
+          Deprecated: This API version (v1beta1) has been deprecated in release v1.1.0.
         properties:
           apiVersion:
             description: |-
@@ -8071,7 +8074,7 @@ spec:
         - spec
         type: object
     served: true
-    storage: true
+    storage: false
     subresources:
       status: {}
   - additionalPrinterColumns:
@@ -15355,6 +15358,6 @@ spec:
         - spec
         type: object
     served: true
-    storage: false
+    storage: true
     subresources:
       status: {}

--- a/package/crds/container.gcp-beta.upbound.io_nodepools.yaml
+++ b/package/crds/container.gcp-beta.upbound.io_nodepools.yaml
@@ -31,11 +31,14 @@ spec:
     - jsonPath: .metadata.creationTimestamp
       name: AGE
       type: date
+    deprecated: true
+    deprecationWarning: This API version is deprecated. Deprecated since v1.1.0.
     name: v1beta1
     schema:
       openAPIV3Schema:
-        description: NodePool is the Schema for the NodePools API. Manages a GKE NodePool
-          resource.
+        description: |-
+          NodePool is the Schema for the NodePools API. Manages a GKE NodePool resource.
+          Deprecated: This API version (v1beta1) has been deprecated in release v1.1.0.
         properties:
           apiVersion:
             description: |-
@@ -2468,7 +2471,7 @@ spec:
         - spec
         type: object
     served: true
-    storage: true
+    storage: false
     subresources:
       status: {}
   - additionalPrinterColumns:
@@ -4714,6 +4717,6 @@ spec:
         - spec
         type: object
     served: true
-    storage: false
+    storage: true
     subresources:
       status: {}


### PR DESCRIPTION
### Description of your changes

This PR bumps the storage & controller versions for CRDs that support multiple versions and starts the deprecation process for the old versions.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

- examples/container/cluster/v1beta2/nodepool.yaml: https://github.com/upbound/provider-upjet-gcp-beta/actions/runs/25720643383
- examples/container/cluster/v1beta1/nodepool.yaml: https://github.com/upbound/provider-upjet-gcp-beta/actions/runs/25721620573

[contribution process]: https://git.io/fj2m9
